### PR TITLE
fix: updated url regex

### DIFF
--- a/src/utils/regularRules.js
+++ b/src/utils/regularRules.js
@@ -1,2 +1,2 @@
 // eslint-disable-next-line no-useless-escape
-export const gitRules = /^(http(s)?:\/\/([^\/]+?\/){2}|git@[^:]+:[^\/]+?\/).*?.git$/;
+export const gitRules = /^(http(s)?:\/\/([^\/]+?\/){2}|git@[^:]+:[^\/]+?\/).*?$/;


### PR DESCRIPTION
目前的 regex 只能匹配以 .git 结尾的 url，无法添加分支名，如：https://github.com/wenfangdu/taro-nutui/tree/promise 给复现问题造成了很大的麻烦。

Fixes #33 